### PR TITLE
Fix body content spacing when there is a sidebar

### DIFF
--- a/src/styles/core/_breakpoints.scss
+++ b/src/styles/core/_breakpoints.scss
@@ -329,7 +329,8 @@ $breakpoint-attributes: (
     min-width: map-deep-get($breakpoint-attributes, (default, small, min-width));
     margin-left: auto;
     margin-right: auto;
-    padding: 0 20px;
+    padding-left: 20px;
+    padding-right: 20px;
     box-sizing: border-box;
 
     // make sure there is 120px space around the content on xlarge


### PR DESCRIPTION
Bug/issue #, if applicable: 89650008, 89650141

## Summary
Fixing the missing padding between the topic sections when a sidebar is present.

**Before:**  

<img width="872" alt="Screen Shot 2022-03-03 at 9 51 48 AM" src="https://user-images.githubusercontent.com/87735557/156622915-3b8d1e5d-5772-4522-a2cd-92cecf066157.png">

**After:**

<img width="864" alt="Screen Shot 2022-03-03 at 9 53 53 AM" src="https://user-images.githubusercontent.com/87735557/156623093-7f5e244a-339f-4e46-8f7b-0d9f6fd04caf.png">

## Testing
Steps:
1. Run `swift-docc-render` with a docc-archive. 
2. Verify that padding-bottom is 40px (between the last section and the footer and between each sections)

## Checklist
- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
