### PR TITLE
Remove ribbon when technology list is empty, or matches root path

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -58,6 +58,7 @@
           :isSymbolDeprecated="isSymbolDeprecated"
           :isSymbolBeta="isSymbolBeta"
           :languagePaths="languagePaths"
+          :rootPath="technology.title"
         />
       </component>
     </template>

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -107,7 +107,7 @@ const sampleCodeDownload = {
 
 const propsData = {
   abstract: [abstract],
-  conformance: { constraints: [], availabilityPrefx: [] },
+  conformance: { constraints: [], availabilityPrefix: [] },
   hierarchy: {
     paths: [
       [
@@ -117,6 +117,7 @@ const propsData = {
     ],
   },
   identifier: 'doc://fookit',
+  rootPath: 'fookit',
   interfaceLanguage: 'swift',
   symbolKind: TopicTypes.module,
   objcPath: 'documentation/objc',
@@ -325,6 +326,13 @@ describe('DocumentationTopic', () => {
       getSetting.mockResolvedValueOnce(true);
       wrapper = shallowMount(DocumentationTopic, { propsData });
       expect(wrapper.find(Summary).exists()).toBe(false);
+    });
+
+    it('renders the Summary, if more than 1 module', () => {
+      const modules = ['FooKit', 'BarKit'];
+      wrapper.setProps({ modules });
+      // wrapper = shallowMount(DocumentationTopic, { propsData });
+      expect(wrapper.find(Summary).exists()).toBe(true);
     });
 
     it('renders a `Availability` with platforms data', () => {

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -65,6 +65,7 @@ const topicData = {
     interfaceLanguage: 'swift',
     url: 'doc://com.example.documentation/documentation/fookit',
   },
+  rootPath: 'FooTechnology',
   metadata: {
     roleHeading: 'Thing',
     role: 'article',
@@ -280,6 +281,7 @@ describe('DocumentationTopic', () => {
         occ: ['documentation/objc'],
         swift: ['documentation/swift'],
       },
+      rootPath: topicData.rootPath,
     });
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 88214559, 89672818

## Summary
1. The grey ribbon shouldn't be present if the technology list is empty
2. We should hide "framework" metadata on pages where that info matches the root framework in the breadcrumb.

## Testing
Steps:
To test #1, go to a `SlothCreator` page.

To test #2, if you have access to a documentation archive that includes a page where the “framework” metadata does not match the root framework in the breadcrumb, navigate to the page and verify that the ribbon is not rendered.

## Checklist
- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
