### PR TITLE
Simplify logic for showing technology badges

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -298,7 +298,7 @@ export default {
         list.push(module.name);
         return list.concat(module.relatedModules || []);
       }, []);
-      // only badges for technologies when there are multiple
+      // only show badges for technologies when there are multiple
       return technologyList.length > 1
         ? technologyList
         : [];

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -251,10 +251,6 @@ export default {
       type: String,
       default: '',
     },
-    technology: {
-      type: Object,
-      required: true,
-    },
   },
   provide() {
     // NOTE: this is not reactive: if this.references change, the provided value
@@ -297,15 +293,15 @@ export default {
     shouldShowLanguageSwitcher: ({ objcPath, swiftPath }) => objcPath && swiftPath,
     hideSummary: () => getSetting(['features', 'docs', 'summary', 'hide'], false),
     enhanceBackground: ({ symbolKind }) => (symbolKind ? (symbolKind === 'module') : true),
-    technologies({ modules = [], technology }) {
+    technologies({ modules = [] }) {
       const technologyList = modules.reduce((list, module) => {
         list.push(module.name);
         return list.concat(module.relatedModules || []);
       }, []);
-      // show modules if page belongs to/require multiple technologies
-      // or if name doesn't match root of page
-      return technologyList.length === 1
-        && technologyList[0] === technology.title ? [] : technologyList;
+      // only badges for technologies when there are multiple
+      return technologyList.length > 1
+        ? technologyList
+        : [];
     },
   },
   methods: {

--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -62,7 +62,6 @@
           :isSymbolDeprecated="isSymbolDeprecated"
           :isSymbolBeta="isSymbolBeta"
           :languagePaths="languagePaths"
-          :technology="technology"
         />
       </component>
     </template>

--- a/tests/unit/views/DocumentationTopic.spec.js
+++ b/tests/unit/views/DocumentationTopic.spec.js
@@ -295,7 +295,6 @@ describe('DocumentationTopic', () => {
         occ: ['documentation/objc'],
         swift: ['documentation/swift'],
       },
-      technology: topicData.references['topic://foo'],
     });
   });
 


### PR DESCRIPTION
Bug/issue #, if applicable: 90330679

## Summary

This updates the logic for conditionally showing "Technology" badges so that they are only shown when there are more than one to display since that is the important use case to show this information.

## Testing

Find examples of pages with more than one technology and ensure that the badges are still displayed and they are not displayed on any other pages.