### PR TITLE
Add right margin to the first item in the Nav bar

### DIFF
--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -196,6 +196,14 @@ $sidenav-icon-size: 19px;
   &-settings {
     @include font-styles(nav-toggles);
 
+    .nav-menu-setting:first-child:not(:only-child) {
+      margin-right: $nav-space-between-elements;
+
+      @include nav-in-breakpoint() {
+        margin-right: 0;
+      }
+    }
+
     @include breakpoint-only-largenav() {
       margin-left: $nav-space-between-elements;
     }

--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -196,26 +196,39 @@ $sidenav-icon-size: 19px;
   &-settings {
     @include font-styles(nav-toggles);
 
-    .nav-menu-setting:first-child:not(:only-child) {
-      margin-right: $nav-space-between-elements;
-
-      @include nav-in-breakpoint() {
-        margin-right: 0;
-      }
-    }
-
     @include breakpoint-only-largenav() {
       margin-left: $nav-space-between-elements;
     }
 
-    @include nav-in-breakpoint {
-      padding-top: 0;
+    .nav-menu-setting {
+      display: flex;
+      align-items: center;
+      color: var(--color-nav-current-link);
+      margin-left: 0;
 
-      &:not([data-previous-menu-children-count="0"]) {
-        .nav-menu-setting:first-child {
-          border-top: 1px solid dark-color(figure-gray-tertiary);
-          display: flex;
-          align-items: center;
+      &:first-child:not(:only-child) {
+        margin-right: $nav-space-between-elements;
+
+        @include nav-in-breakpoint() {
+          margin-right: 0;
+        }
+      }
+
+      @include nav-dark() {
+        color: var(--color-nav-dark-current-link);
+      }
+
+      @include nav-in-breakpoint() {
+        &:not([data-previous-menu-children-count="0"]) {
+          &:first-child {
+            border-top: 1px solid dark-color(figure-gray-tertiary);
+            display: flex;
+            align-items: center;
+          }
+        }
+
+        &:not(:first-child) {
+          border-top: 1px solid dark-color(fill-gray-tertiary);
         }
       }
     }

--- a/src/components/DocumentationTopic/DocumentationNav.vue
+++ b/src/components/DocumentationTopic/DocumentationNav.vue
@@ -200,6 +200,17 @@ $sidenav-icon-size: 19px;
       margin-left: $nav-space-between-elements;
     }
 
+    @include nav-in-breakpoint {
+      // do not apply border if no item are above setting links
+      &:not([data-previous-menu-children-count="0"]) {
+        .nav-menu-setting:first-child {
+          border-top: 1px solid dark-color(figure-gray-tertiary);
+          display: flex;
+          align-items: center;
+        }
+      }
+    }
+
     .nav-menu-setting {
       display: flex;
       align-items: center;
@@ -219,14 +230,6 @@ $sidenav-icon-size: 19px;
       }
 
       @include nav-in-breakpoint() {
-        &:not([data-previous-menu-children-count="0"]) {
-          &:first-child {
-            border-top: 1px solid dark-color(figure-gray-tertiary);
-            display: flex;
-            align-items: center;
-          }
-        }
-
         &:not(:first-child) {
           border-top: 1px solid dark-color(fill-gray-tertiary);
         }


### PR DESCRIPTION
Bug/issue #, if applicable: 90568720, 88280711

## Summary
Add right margin to the first item in the Nav bar

## Testing
Steps:
1. Verify that if there are more than one item in the nav bar, a margin-right is added
2. If it's the only item, there should be no margin. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
