### PR TITLE
Use dark theme link color in documentation in hero

### DIFF
--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -153,7 +153,7 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
   }
 }
 
-/deep/ a {
+.theme-dark /deep/ a {
   color: dark-color(figure-blue);
 }
 </style>

--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -152,4 +152,8 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
     content: none;
   }
 }
+
+/deep/ a {
+  color: dark-color(figure-blue);
+}
 </style>


### PR DESCRIPTION
Bug/issue #, if applicable: 89691924

## Summary

Since the documentation hero uses a dark theme, links inside it should always use the dark theme color, regardless of the selected color scheme for the overall page.

## Testing

Steps:
1. Download/unzip [example.zip](https://github.com/dobromir-hristov/swift-docc-render/files/8328193/example.zip)
2. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/unzipped/example npm run serve` 
3. Open http://localhost:8080/documentation/swiftdoccrender and verify that the "DocC" link in the hero abstract always stays the same color (dark mode "figure-blue"), regardless of what setting you select in the color scheme toggle. If you select "Light", the color should differ from the color of other links on the page. If you select "Dark", the color should match the color of other links on the page.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary