### PR TITLE
Render "Beta" or "Deprecated" in documentation title

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -19,7 +19,11 @@
           :objcPath="objcPath"
           :swiftPath="swiftPath"
         />
-        <Title :eyebrow="roleHeading">{{ title }}</Title>
+        <Title :eyebrow="roleHeading">
+          {{ title }}
+          <small v-if="isSymbolDeprecated" slot="after" class="deprecated">Deprecated</small>
+          <small v-else-if="isSymbolBeta" slot="after" class="beta">Beta</small>
+        </Title>
         <Abstract v-if="abstract" :content="abstract" />
         <div v-if="sampleCodeDownload">
           <DownloadButton class="sample-download" :action="sampleCodeDownload.action" />

--- a/src/components/DocumentationTopic/Title.vue
+++ b/src/components/DocumentationTopic/Title.vue
@@ -11,7 +11,10 @@
 <template>
   <div class="topictitle">
     <span v-if="eyebrow" class="eyebrow">{{eyebrow}}</span>
-    <WordBreak class="title" tag="h1"><slot /></WordBreak>
+    <WordBreak class="title" tag="h1">
+      <slot />
+      <slot name="after" />
+    </WordBreak>
   </div>
 </template>
 
@@ -51,6 +54,26 @@ export default {
 
   .documentation-hero--disabled & {
     color: var(--colors-header-text, var(--color-header-text));
+  }
+}
+
+small {
+  @include font-styles(eyebrow);
+
+  &.beta {
+    color: var(--color-badge-beta);
+
+    .theme-dark & {
+      color: var(--color-badge-dark-beta);
+    }
+  }
+
+  &.deprecated {
+    color: var(--color-badge-deprecated);
+
+    .theme-dark & {
+      color: var(--color-badge-dark-deprecated);
+    }
   }
 }
 </style>

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -248,6 +248,46 @@ describe('DocumentationTopic', () => {
     expect(title.text()).toBe(propsData.title);
   });
 
+  it('renders smaller "Beta" and "Deprecated" text in title when relevant', () => {
+    const title = wrapper.find(Title);
+    expect(title.exists()).toBe(true);
+    let smalls = title.findAll('small');
+    expect(smalls.length).toBe(0);
+
+    // both beta _and_ deprecated — deprecated has priority
+    wrapper.setProps({
+      isSymbolDeprecated: true,
+      isSymbolBeta: true,
+    });
+    smalls = title.findAll('small');
+    expect(smalls.length).toBe(1);
+    expect(smalls.at(0).is('.beta')).toBe(false);
+    expect(smalls.at(0).is('.deprecated')).toBe(true);
+    expect(smalls.at(0).text()).toBe('Deprecated');
+
+    // only beta
+    wrapper.setProps({
+      isSymbolDeprecated: false,
+      isSymbolBeta: true,
+    });
+    smalls = title.findAll('small');
+    expect(smalls.length).toBe(1);
+    expect(smalls.at(0).is('.beta')).toBe(true);
+    expect(smalls.at(0).is('.deprecated')).toBe(false);
+    expect(smalls.at(0).text()).toBe('Beta');
+
+    // both beta _and_ deprecated — deprecated has priority
+    wrapper.setProps({
+      isSymbolDeprecated: true,
+      isSymbolBeta: false,
+    });
+    smalls = title.findAll('small');
+    expect(smalls.length).toBe(1);
+    expect(smalls.at(0).is('.beta')).toBe(false);
+    expect(smalls.at(0).is('.deprecated')).toBe(true);
+    expect(smalls.at(0).text()).toBe('Deprecated');
+  });
+
   it('renders an abstract', () => {
     const hero = wrapper.find(DocumentationHero);
     const abstractComponent = hero.find(Abstract);

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -276,7 +276,7 @@ describe('DocumentationTopic', () => {
     expect(smalls.at(0).is('.deprecated')).toBe(false);
     expect(smalls.at(0).text()).toBe('Beta');
 
-    // both beta _and_ deprecated — deprecated has priority
+    // only deprecated
     wrapper.setProps({
       isSymbolDeprecated: true,
       isSymbolBeta: false,


### PR DESCRIPTION
Bug/issue #, if applicable: 90170811

## Summary

Adds smaller "Beta" or "Deprecated" text to the h1 title for documentation pages when it applies.

## Dependencies

https://github.com/dobromir-hristov/swift-docc-render/pull/3

## Testing

Find example beta/deprecated symbol pages and verify that the text now renders with a smaller font inline with the h1 title (in the appropriate color).

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
