### PR TITLE
Add margin-top and Remove margin-left for items in Relationship Section

### DIFF
--- a/src/components/DocumentationTopic/RelationshipsList.vue
+++ b/src/components/DocumentationTopic/RelationshipsList.vue
@@ -128,6 +128,11 @@ export default {
 .relationships-list {
   list-style: none;
 
+  &.column {
+    margin-left: 0;
+    margin-top: 15px;
+  }
+
   // The "inline" style displays items on a single line as a
   // comma-separated list with a maximum number of 3 items. This style should
   // not be used for a list that contains any items with availability


### PR DESCRIPTION
Bug/issue #, if applicable: 90964249

## Summary
Addressing PR feedback: https://github.com/dobromir-hristov/swift-docc-render/pull/3/files#r818184276
Adding margin-top and removing margin-left for the items in the Relationship Section.
Creating this new PR, since the original PR has become really large and hard to review. 

## Testing
See screenshot for Before and After:

**Before:**
<img width="842" alt="Before" src="https://user-images.githubusercontent.com/87735557/160539052-61fde239-9e80-4407-bcef-b3025a4b44e8.png">

**After:**
<img width="1192" alt="After" src="https://user-images.githubusercontent.com/87735557/160539295-8c8a80aa-8928-4c98-afe9-6a1b80fa790a.png">


## Checklist
- [ ] Added tests - NA
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary - NA
