### PR TITLE
Don't override button link color in doc hero

### DIFF
--- a/src/components/DocumentationTopic/DocumentationHero.vue
+++ b/src/components/DocumentationTopic/DocumentationHero.vue
@@ -153,7 +153,7 @@ $doc-hero-icon-color: dark-color(fill-secondary) !default;
   }
 }
 
-.theme-dark /deep/ a {
+.theme-dark /deep/ a:not(.button-cta) {
   color: dark-color(figure-blue);
 }
 </style>


### PR DESCRIPTION
Bug/issue #, if applicable: 90999537

## Summary

Fixes an issue where the sample code button text color is accidentally being overwritten to blue instead of white, which makes it look disabled.

## Testing

Steps:
1. Open an example sample code page with the download button
2. Verify that the download button text is white again instead of blue

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~, CSS only change
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
